### PR TITLE
Wait for Dialog to close before exiting

### DIFF
--- a/Setup Your Mac/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup Your Mac/Setup-Your-Mac-via-Dialog.bash
@@ -351,6 +351,7 @@ function finalise(){
     dialog_update "button1: enable"
     rm "$dialogCommandFile"
     rm "$welcomeScreenCommandFile"
+    wait
     exit "${exitCode}"
 }
 


### PR DESCRIPTION
When running the Setup your Mac.bash script from a Jamf policy, the dialog window will automatically close once Jamf is done executing the policy. This does not give the user a chance to review the status and read the final message update.

`wait` will wait block until all background jobs have completed.