### PR TITLE
Add Window Position to Jamf Policy Variables

### DIFF
--- a/Inventory Update Progress/swiftDialog-Inventory-Update-Progress.bash
+++ b/Inventory Update Progress/swiftDialog-Inventory-Update-Progress.bash
@@ -51,6 +51,7 @@ inventoryLog=$( mktemp /var/tmp/inventoryLog.XXX )
 scriptLog="${4:-"/var/tmp/org.churchofjesuschrist.log"}"
 estimatedTotalSeconds="${5:-"298"}"
 debugMode="${6:-"false"}"
+windowPosition="${7:-"center"}"
 
 
 
@@ -73,6 +74,7 @@ dialogInventoryUpdate="$dialogApp \
 --title \"$title\" \
 --message \"$message\" \
 --icon \"$icon\" \
+--position \"$windowPosition\" \
 --mini \
 --moveable \
 --progress \


### PR DESCRIPTION
Adds windowPosition as a Parameter 7 for Jamf policies.  If not set, it defaults to Center.  Makes it easier for an admin to reposition as their environment sees fit without touching the script itself.